### PR TITLE
Fix the duplicate friends issue #24

### DIFF
--- a/TicText-iOS/TicText.xcodeproj/project.pbxproj
+++ b/TicText-iOS/TicText.xcodeproj/project.pbxproj
@@ -664,8 +664,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Developer: Kevin Yufei Chen (L26MMJT3VJ)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Kevin Yufei Chen (L26MMJT3VJ)";
 				GCC_PREFIX_HEADER = "TicText/TicText-Prefix.pch";
 				INFOPLIST_FILE = TicText/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
@@ -681,8 +681,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Developer: Kevin Yufei Chen (L26MMJT3VJ)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Kevin Yufei Chen (L26MMJT3VJ)";
 				GCC_PREFIX_HEADER = "TicText/TicText-Prefix.pch";
 				INFOPLIST_FILE = TicText/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
@@ -697,8 +697,8 @@
 			baseConfigurationReference = 579798160077DEF631AAECA1 /* Pods-TicTextTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Developer: Kevin Yufei Chen (L26MMJT3VJ)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Kevin Yufei Chen (L26MMJT3VJ)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -721,8 +721,8 @@
 			baseConfigurationReference = 65E0D8574E683EDF0172C6F3 /* Pods-TicTextTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Developer: Kevin Yufei Chen (L26MMJT3VJ)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Kevin Yufei Chen (L26MMJT3VJ)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",

--- a/TicText-iOS/TicText/TTConstants.h
+++ b/TicText-iOS/TicText/TTConstants.h
@@ -49,6 +49,12 @@ extern NSUInteger const kTTSessionErrorParseSessionFetchFailureCode;
 extern NSUInteger const kTTSessionErrorParseSessionInvalidUUIDCode;
 
 
+#pragma mark - Parse Local Datastore
+// Pin names
+extern NSString * const kTTLocalDatastoreFriendsPinName;
+extern NSString * const kTTLocalDatastoreTicsPinName;
+
+
 #pragma mark - TTUser
 // Field keys
 extern NSString * const kTTUserDisplayNameKey;

--- a/TicText-iOS/TicText/TTConstants.m
+++ b/TicText-iOS/TicText/TTConstants.m
@@ -46,6 +46,12 @@ NSUInteger const kTTSessionErrorParseSessionFetchFailureCode = 0;
 NSUInteger const kTTSessionErrorParseSessionInvalidUUIDCode = 1;
 
 
+#pragma mark - Parse Local Datastore
+// Pin names
+NSString * const kTTLocalDatastoreFriendsPinName = @"friends";
+NSString * const kTTLocalDatastoreTicsPinName = @"tics";
+
+
 #pragma mark - TTUser
 // Field keys
 NSString * const kTTUserDisplayNameKey = @"displayName";

--- a/TicText-iOS/TicText/TTMessagesViewController.m
+++ b/TicText-iOS/TicText/TTMessagesViewController.m
@@ -176,7 +176,7 @@
                                                    type:TSMessageNotificationTypeError];
         } else {
             for (TTTic *tic in objects) {
-                [tic unpinInBackground];
+                [tic unpinInBackgroundWithName:kTTLocalDatastoreTicsPinName];
                 [self.jsqMessages removeAllObjects];
                 [self.tics removeAllObjects];
             }
@@ -226,7 +226,7 @@
     
     // New Tic
     TTTic *newTic = [self ticWithType:kTTTicTypeDefault sender:[TTUser currentUser] recipient:self.recipient timeLimit:10 message:newJSQMessage];
-    [newTic pinInBackground];
+    [newTic pinInBackgroundWithName:kTTLocalDatastoreTicsPinName];
     
     // Add to local array
     [self.tics addObject:newTic];
@@ -377,7 +377,7 @@
 
     [TTTic fetchTicInBackgroundWithId:unreadTic.objectId timestamp:[NSDate date] completion:^(TTTic *fetchedTic, NSError *error) {
         if (fetchedTic) {
-            [fetchedTic pinInBackground];
+            [fetchedTic pinInBackgroundWithName:kTTLocalDatastoreTicsPinName];
             fetchedTic.status = kTTTicStatusRead;
             JSQMessage *fetchedJSQMessage = [self jsqMessageWithTic:fetchedTic];
             [self.tics replaceObjectAtIndex:indexPath.item withObject:fetchedTic];

--- a/TicText-iOS/TicText/TTSession.m
+++ b/TicText-iOS/TicText/TTSession.m
@@ -236,7 +236,11 @@
             if (error) {
                 NSLog(@"%@", error);
             } else {
-                [TTUser pinAllInBackground:objects];
+                [TTUser unpinAllObjectsInBackgroundWithName:kTTLocalDatastoreFriendsPinName block:^(BOOL succeeded, NSError *error) {
+                    if (succeeded) {
+                        [TTUser pinAllInBackground:objects withName:kTTLocalDatastoreFriendsPinName];
+                    }
+                }];
             }
         }];
     }];


### PR DESCRIPTION
This is the fix for Issue #24 
Add names to different pins, and remove all stored friends object before `fetchAndPin` again. 

**You may have to delete and reinstall the app to apply this fix.**
